### PR TITLE
Add @HPCpodcast RSS feed

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -18,3 +18,8 @@
   url: https://www.openmp.org/
   feed: https://www.openmp.org/feed/
   image: https://www.openmp.org/wp-content/uploads/cropped-openmp-site-icon-32x52.jpg
+- name: "@HPCpodcast with Shahin Khan and Doug Black"
+  tag: "hpcpodcast"
+  url: https://orionx.net/podcast/
+  feed: https://orionx.net/category/hpc-podcast/feed/
+  image: https://orionx.net/wp-content/uploads/2022/02/%40HPCpodcast_logo.svg


### PR DESCRIPTION
Adds @HPCpodcast with Shahin Khan and Doug Black to the HPC.social community feed, including the podcast page, RSS feed, and show image.

The show provides weekly HPC News Bytes and longer discussions covering supercomputing, AI, quantum computing, infrastructure, markets and technology policy. 

The content is editorial rather than product promotional. Please redirect this submission to the commercial feed if that classification is more appropriate.